### PR TITLE
Improvements of publishing process

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-src
-spec
-coverage
-tsconfig.json
-tslint.json
-.prettierrc
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test": "ts-node node_modules/jasmine/bin/jasmine.js",
     "test:coverage": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts  -x \"*.d.ts\" -x \"*.spec.ts\" node_modules/jasmine/bin/jasmine.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "scripts": {
     "test": "ts-node node_modules/jasmine/bin/jasmine.js",
     "test:coverage": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts  -x \"*.d.ts\" -x \"*.spec.ts\" node_modules/jasmine/bin/jasmine.js",
-    "build": "tsc"
+    "build": "tsc",
+    "preversion": "npm test",
+    "postversion": "git push && git push --tags",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This:
- adds some publishing hooks, so that it becomes simpler
- whitelists `lib` as the directory to publish (the standard files like `package.json`, `README.md` get published as well), but we don't have to keep a file ignoring most of the project files