### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.1.1](https://github.com/thewca/wca-helpers/tree/v1.1.1) (2022-05-12)
+
+### Added
+
+* Functions for encoding and decoding activity codes
+
+### Changed
+
+* Updated model definitions to match the latest WCIF
+
+## [v1.0.0](https://github.com/thewca/wca-helpers/tree/v1.0.0) (2018-10-13)
+
+Initial release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wca/helpers",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wca/helpers",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "GPL",
       "devDependencies": {
         "@types/jasmine": "^2.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wca/helpers",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Helpers and class definitions for WCA and WCIF",
   "keywords": [
     "wca",


### PR DESCRIPTION
The current version on npm is v1.1.0, but in `package.json` it's v1.0.0. @ronaldmansveld any insights into why that's the case?