### PR TITLE
Fix `childActivities` type

### DIFF
--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -8,7 +8,7 @@ export interface Activity {
   activityCode: ActivityCode;
   startTime: string;
   endTime: string;
-  childActivities: Activity[] | null;
+  childActivities: Activity[];
   scrambleSetId?: number | null;
-  extensions: Extension[]
+  extensions: Extension[];
 }


### PR DESCRIPTION
I was getting a 400 error when I tried to pass null:

```The property '#/schedule/venues/0/rooms/0/activities/7/childActivities' of type null did not match the following type: array```

(sry  didn't mean to close/reopen!)