### PR TITLE
Add two new helper functions to format AttemptResults

### DIFF
--- a/spec/result.spec.ts
+++ b/spec/result.spec.ts
@@ -167,10 +167,22 @@ describe('Result helper', function () {
     ).toEqual('6 points');
   });
 
+  it('Correctly Formats 333 Result in Second', function () {
+    expect(
+      attemptResultToString({ attemptResult: 100, eventId: '333' }),
+    ).toEqual('1 second');
+  });
+
   it('Correctly Formats 333 Result in Seconds', function () {
     expect(
       attemptResultToString({ attemptResult: 3000, eventId: '333' }),
     ).toEqual('30 seconds');
+  });
+
+  it('Correctly Formats 333 Result in Minute', function () {
+    expect(
+      attemptResultToString({ attemptResult: 6000, eventId: '333' }),
+    ).toEqual('1 minute');
   });
 
   it('Correctly Formats 333 Result in Minutes', function () {
@@ -179,9 +191,15 @@ describe('Result helper', function () {
     ).toEqual('1 minute 30 seconds');
   });
 
-  it('Correctly Formats 333 Result in hours', function () {
+  it('Correctly Formats 333 Result in hour', function () {
     expect(
       attemptResultToString({ attemptResult: 360000, eventId: '333' }),
     ).toEqual('1 hour');
+  });
+
+  it('Correctly Formats 333 Result in hours', function () {
+    expect(
+      attemptResultToString({ attemptResult: 369000, eventId: '333' }),
+    ).toEqual('1 hour 1 minute 30 seconds');
   });
 });

--- a/spec/result.spec.ts
+++ b/spec/result.spec.ts
@@ -149,5 +149,26 @@ describe('Result helper', function () {
     expect(decodeMultiResult(979999902)).toEqual({ solved: 4, attempted: 6 });
   });
 
-  it('Correctly Formats Attempt Results ')
+  it('Correctly Formats FMC Result', function (){
+    expect(attemptResultToString({ attemptResult: 24, eventId: '333fm' })).toEqual('24 moves')
+  })
+
+  it('Correctly Formats MBLD Result', function (){
+    expect(attemptResultToString({ attemptResult: encodeMultiResult({
+        solved: 6,
+        attempted: 6,
+      }), eventId: '333mbf' })).toEqual('6 points')
+  })
+
+  it('Correctly Formats 333 Result in Seconds', function (){
+    expect(attemptResultToString({attemptResult: 3000, eventId: "333"})).toEqual("30 seconds")
+  })
+
+  it('Correctly Formats 333 Result in Minutes', function (){
+    expect(attemptResultToString({attemptResult: 9000, eventId: "333"})).toEqual("1 minute 30 seconds")
+  })
+
+  it('Correctly Formats 333 Result in hours', function (){
+    expect(attemptResultToString({attemptResult: 360000, eventId: "333"})).toEqual("1 hour")
+  })
 });

--- a/spec/result.spec.ts
+++ b/spec/result.spec.ts
@@ -149,26 +149,39 @@ describe('Result helper', function () {
     expect(decodeMultiResult(979999902)).toEqual({ solved: 4, attempted: 6 });
   });
 
-  it('Correctly Formats FMC Result', function (){
-    expect(attemptResultToString({ attemptResult: 24, eventId: '333fm' })).toEqual('24 moves')
-  })
+  it('Correctly Formats FMC Result', function () {
+    expect(
+      attemptResultToString({ attemptResult: 24, eventId: '333fm' }),
+    ).toEqual('24 moves');
+  });
 
-  it('Correctly Formats MBLD Result', function (){
-    expect(attemptResultToString({ attemptResult: encodeMultiResult({
-        solved: 6,
-        attempted: 6,
-      }), eventId: '333mbf' })).toEqual('6 points')
-  })
+  it('Correctly Formats MBLD Result', function () {
+    expect(
+      attemptResultToString({
+        attemptResult: encodeMultiResult({
+          solved: 6,
+          attempted: 6,
+        }),
+        eventId: '333mbf',
+      }),
+    ).toEqual('6 points');
+  });
 
-  it('Correctly Formats 333 Result in Seconds', function (){
-    expect(attemptResultToString({attemptResult: 3000, eventId: "333"})).toEqual("30 seconds")
-  })
+  it('Correctly Formats 333 Result in Seconds', function () {
+    expect(
+      attemptResultToString({ attemptResult: 3000, eventId: '333' }),
+    ).toEqual('30 seconds');
+  });
 
-  it('Correctly Formats 333 Result in Minutes', function (){
-    expect(attemptResultToString({attemptResult: 9000, eventId: "333"})).toEqual("1 minute 30 seconds")
-  })
+  it('Correctly Formats 333 Result in Minutes', function () {
+    expect(
+      attemptResultToString({ attemptResult: 9000, eventId: '333' }),
+    ).toEqual('1 minute 30 seconds');
+  });
 
-  it('Correctly Formats 333 Result in hours', function (){
-    expect(attemptResultToString({attemptResult: 360000, eventId: "333"})).toEqual("1 hour")
-  })
+  it('Correctly Formats 333 Result in hours', function () {
+    expect(
+      attemptResultToString({ attemptResult: 360000, eventId: '333' }),
+    ).toEqual('1 hour');
+  });
 });

--- a/spec/result.spec.ts
+++ b/spec/result.spec.ts
@@ -6,6 +6,7 @@ import {
   isMultiResultDnf,
   encodeMultiResult,
   formatMultiResult,
+  attemptResultToString,
 } from '../src/helpers/result';
 
 describe('Result helper', function () {
@@ -147,4 +148,6 @@ describe('Result helper', function () {
   it('Correctly decodes new style multi result', function () {
     expect(decodeMultiResult(979999902)).toEqual({ solved: 4, attempted: 6 });
   });
+
+  it('Correctly Formats Attempt Results ')
 });

--- a/spec/time.spec.ts
+++ b/spec/time.spec.ts
@@ -1,4 +1,4 @@
-import { formatCentiseconds } from '../src/helpers/time';
+import { formatCentiseconds, pluralize } from '../src/helpers/time';
 
 describe('Time Helper', function () {
   it('Correctly formats DNF', function () {
@@ -51,5 +51,19 @@ describe('Time Helper', function () {
   it('Correctly formats times > 1 hour as in minutes', function () {
     expect(formatCentiseconds(360000)).toBe('60:00.00');
     expect(formatCentiseconds(360400)).toBe('60:04.00');
+  });
+
+  it('Correctly pluralizes', function () {
+    expect(pluralize({ count: 2, word: 'Cube' })).toEqual('2 Cubes');
+  });
+
+  it('Doesnt pluralize if the count is 1', function () {
+    expect(pluralize({ count: 1, word: 'Cube' })).toEqual('1 Cube');
+  });
+
+  it('Abbreviates Correctly', function () {
+    expect(
+      pluralize({ count: 1, word: 'hour', options: { abbreviate: true } }),
+    ).toEqual('1h');
   });
 });

--- a/src/helpers/result.ts
+++ b/src/helpers/result.ts
@@ -1,5 +1,7 @@
 import { AttemptResult } from '../models/attemptResult';
-import { formatCentiseconds } from './time';
+import {centiSecondsToHumanReadable, formatCentiseconds} from './time';
+import {EventId} from "../models";
+import {getEventResultType} from "./event";
 
 type DnfMultiResult = { isDnf: true };
 type DnsMultiResult = { isDns: true };
@@ -119,4 +121,29 @@ function decodeNewMultiResult(result: AttemptResult): DecodedMultiResult {
   }
 
   return res;
+}
+
+interface AttemptResultToStringParams {
+  attemptResult: number
+  eventId: EventId
+}
+
+function attemptResultToMbPoints(mbValue: number) {
+  const { solved, attempted } = decodeMultiResult(mbValue)
+  const missed = attempted - solved
+  return solved - missed
+}
+
+export function attemptResultToString({
+                                        attemptResult,
+                                        eventId,
+                                      }: AttemptResultToStringParams) {
+  const type = getEventResultType(eventId)
+  if (type === 'time') {
+    return centiSecondsToHumanReadable({ c: attemptResult })
+  }
+  if (type === 'number') {
+    return `${attemptResult} moves`
+  }
+  return `${attemptResultToMbPoints(attemptResult)} points`
 }

--- a/src/helpers/result.ts
+++ b/src/helpers/result.ts
@@ -128,12 +128,22 @@ interface AttemptResultToStringParams {
   eventId: EventId;
 }
 
+/**
+ * Returns the number of Points a Multi Result is worth
+ * @param mbValue
+ */
 function attemptResultToMbPoints(mbValue: number) {
   const { solved, attempted } = decodeMultiResult(mbValue);
   const missed = attempted - solved;
   return solved - missed;
 }
 
+/**
+ * Formats an Attempt Result for Cutoffs and Qualifications
+ * attemptResult can be a time in centiseconds, a number or a MBLD encoded string
+ * @param attemptResult
+ * @param eventId
+ */
 export function attemptResultToString({
   attemptResult,
   eventId,

--- a/src/helpers/result.ts
+++ b/src/helpers/result.ts
@@ -1,7 +1,7 @@
 import { AttemptResult } from '../models/attemptResult';
-import {centiSecondsToHumanReadable, formatCentiseconds} from './time';
-import {EventId} from "../models";
-import {getEventResultType} from "./event";
+import { centiSecondsToHumanReadable, formatCentiseconds } from './time';
+import { EventId } from '../models';
+import { getEventResultType } from './event';
 
 type DnfMultiResult = { isDnf: true };
 type DnsMultiResult = { isDns: true };
@@ -124,26 +124,26 @@ function decodeNewMultiResult(result: AttemptResult): DecodedMultiResult {
 }
 
 interface AttemptResultToStringParams {
-  attemptResult: number
-  eventId: EventId
+  attemptResult: number;
+  eventId: EventId;
 }
 
 function attemptResultToMbPoints(mbValue: number) {
-  const { solved, attempted } = decodeMultiResult(mbValue)
-  const missed = attempted - solved
-  return solved - missed
+  const { solved, attempted } = decodeMultiResult(mbValue);
+  const missed = attempted - solved;
+  return solved - missed;
 }
 
 export function attemptResultToString({
-                                        attemptResult,
-                                        eventId,
-                                      }: AttemptResultToStringParams) {
-  const type = getEventResultType(eventId)
+  attemptResult,
+  eventId,
+}: AttemptResultToStringParams) {
+  const type = getEventResultType(eventId);
   if (type === 'time') {
-    return centiSecondsToHumanReadable({ c: attemptResult })
+    return centiSecondsToHumanReadable({ c: attemptResult });
   }
   if (type === 'number') {
-    return `${attemptResult} moves`
+    return `${attemptResult} moves`;
   }
-  return `${attemptResultToMbPoints(attemptResult)} points`
+  return `${attemptResultToMbPoints(attemptResult)} points`;
 }

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -1,7 +1,7 @@
-import { getEventResultType } from './event';
-import { EventId } from '../models';
-import { decodeMultiResult } from './result';
-
+/**
+ * Formats Centiseconds to a string like 3:30 or 0:43
+ * @param centiTime
+ */
 export function formatCentiseconds(centiTime: number): string {
   if (centiTime === -1) {
     return 'DNF';
@@ -18,6 +18,10 @@ export function formatCentiseconds(centiTime: number): string {
   return `${s}.${prefix(cs)}`;
 }
 
+/**
+ * Pads out a number with a 0 if it's under 10
+ * @param n
+ */
 function prefix(n: number): string {
   if (n < 10) {
     return `0${n}`;
@@ -38,6 +42,14 @@ interface PluralizeParams {
   };
 }
 
+/**
+ * Adds an s to a word if count is over 1.
+ * Takes options to pad the count and abbreviate the word with its
+ * first letter
+ * @param count
+ * @param word
+ * @param options
+ */
 function pluralize({ count, word, options = {} }: PluralizeParams) {
   const countStr =
     options.fixed && count % 1 > 0 ? count.toFixed(options.fixed) : count;
@@ -53,6 +65,12 @@ interface CentiSecondsToHumanReadableParams {
     short?: boolean;
   };
 }
+
+/**
+ * Converts Centiseconds to a human-readable string like "5:30 minutes"
+ * @param c
+ * @param options
+ */
 export function centiSecondsToHumanReadable({
   c,
   options = {},

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -50,7 +50,7 @@ interface PluralizeParams {
  * @param word
  * @param options
  */
-function pluralize({ count, word, options = {} }: PluralizeParams) {
+export function pluralize({ count, word, options = {} }: PluralizeParams) {
   const countStr =
     options.fixed && count % 1 > 0 ? count.toFixed(options.fixed) : count;
   const countDesc = options.abbreviate

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -1,6 +1,6 @@
-import {getEventResultType} from "./event";
-import {EventId} from "../models";
-import {decodeMultiResult} from "./result";
+import { getEventResultType } from './event';
+import { EventId } from '../models';
+import { decodeMultiResult } from './result';
 
 export function formatCentiseconds(centiTime: number): string {
   if (centiTime === -1) {
@@ -25,69 +25,69 @@ function prefix(n: number): string {
   return `${n}`;
 }
 
-export const SECOND_IN_CS = 100
-export const MINUTE_IN_CS = 60 * SECOND_IN_CS
-export const HOUR_IN_CS = 60 * MINUTE_IN_CS
+export const SECOND_IN_CS = 100;
+export const MINUTE_IN_CS = 60 * SECOND_IN_CS;
+export const HOUR_IN_CS = 60 * MINUTE_IN_CS;
 
 interface PluralizeParams {
-  count: number
-  word: string
+  count: number;
+  word: string;
   options?: {
-    fixed?: number
-    abbreviate?: boolean
-  }
+    fixed?: number;
+    abbreviate?: boolean;
+  };
 }
 
 function pluralize({ count, word, options = {} }: PluralizeParams) {
   const countStr =
-      options.fixed && count % 1 > 0 ? count.toFixed(options.fixed) : count
+    options.fixed && count % 1 > 0 ? count.toFixed(options.fixed) : count;
   const countDesc = options.abbreviate
-      ? word[0]
-      : ` ${count === 1 ? word : `${word}s`}`
-  return countStr + countDesc
+    ? word[0]
+    : ` ${count === 1 ? word : `${word}s`}`;
+  return countStr + countDesc;
 }
 
 interface CentiSecondsToHumanReadableParams {
-  c: number
+  c: number;
   options?: {
-    short?: boolean
-  }
+    short?: boolean;
+  };
 }
 export function centiSecondsToHumanReadable({
-                                              c,
-                                              options = {},
-                                            }: CentiSecondsToHumanReadableParams) {
-  let centiseconds = c
-  let str = ''
+  c,
+  options = {},
+}: CentiSecondsToHumanReadableParams) {
+  let centiseconds = c;
+  let str = '';
 
-  const hours = centiseconds / HOUR_IN_CS
-  centiseconds %= HOUR_IN_CS
+  const hours = centiseconds / HOUR_IN_CS;
+  centiseconds %= HOUR_IN_CS;
   if (hours >= 1) {
     str += `${pluralize({
       count: Math.floor(hours),
       word: 'hour',
       options: { abbreviate: options.short },
-    })} `
+    })} `;
   }
 
-  const minutes = centiseconds / MINUTE_IN_CS
-  centiseconds %= MINUTE_IN_CS
+  const minutes = centiseconds / MINUTE_IN_CS;
+  centiseconds %= MINUTE_IN_CS;
   if (minutes >= 1) {
     str += `${pluralize({
       count: Math.floor(minutes),
       word: 'minute',
       options: { abbreviate: options.short },
-    })} `
+    })} `;
   }
 
-  const seconds = centiseconds / SECOND_IN_CS
+  const seconds = centiseconds / SECOND_IN_CS;
   if (seconds > 0 || str.length === 0) {
     str += `${pluralize({
       count: seconds,
       word: 'second',
       options: { fixed: 2, abbreviate: options.short },
-    })} `
+    })} `;
   }
 
-  return str.trim()
+  return str.trim();
 }

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -1,3 +1,7 @@
+import {getEventResultType} from "./event";
+import {EventId} from "../models";
+import {decodeMultiResult} from "./result";
+
 export function formatCentiseconds(centiTime: number): string {
   if (centiTime === -1) {
     return 'DNF';
@@ -19,4 +23,71 @@ function prefix(n: number): string {
     return `0${n}`;
   }
   return `${n}`;
+}
+
+export const SECOND_IN_CS = 100
+export const MINUTE_IN_CS = 60 * SECOND_IN_CS
+export const HOUR_IN_CS = 60 * MINUTE_IN_CS
+
+interface PluralizeParams {
+  count: number
+  word: string
+  options?: {
+    fixed?: number
+    abbreviate?: boolean
+  }
+}
+
+function pluralize({ count, word, options = {} }: PluralizeParams) {
+  const countStr =
+      options.fixed && count % 1 > 0 ? count.toFixed(options.fixed) : count
+  const countDesc = options.abbreviate
+      ? word[0]
+      : ` ${count === 1 ? word : `${word}s`}`
+  return countStr + countDesc
+}
+
+interface CentiSecondsToHumanReadableParams {
+  c: number
+  options?: {
+    short?: boolean
+  }
+}
+export function centiSecondsToHumanReadable({
+                                              c,
+                                              options = {},
+                                            }: CentiSecondsToHumanReadableParams) {
+  let centiseconds = c
+  let str = ''
+
+  const hours = centiseconds / HOUR_IN_CS
+  centiseconds %= HOUR_IN_CS
+  if (hours >= 1) {
+    str += `${pluralize({
+      count: Math.floor(hours),
+      word: 'hour',
+      options: { abbreviate: options.short },
+    })} `
+  }
+
+  const minutes = centiseconds / MINUTE_IN_CS
+  centiseconds %= MINUTE_IN_CS
+  if (minutes >= 1) {
+    str += `${pluralize({
+      count: Math.floor(minutes),
+      word: 'minute',
+      options: { abbreviate: options.short },
+    })} `
+  }
+
+  const seconds = centiseconds / SECOND_IN_CS
+  if (seconds > 0 || str.length === 0) {
+    str += `${pluralize({
+      count: seconds,
+      word: 'second',
+      options: { fixed: 2, abbreviate: options.short },
+    })} `
+  }
+
+  return str.trim()
 }


### PR DESCRIPTION
We need this function both in the monolith and in wca-registrations to format AttemptResults (in cutoffs and qualifications)